### PR TITLE
Make dropdowns allow sub-dropdowns correctly

### DIFF
--- a/w3.css
+++ b/w3.css
@@ -48,7 +48,7 @@ hr{border:0;border-top:1px solid #eee;margin:20px 0}
 .w3-input{padding:8px;display:block;border:none;border-bottom:1px solid #ccc;width:100%}
 .w3-select{padding:9px 0;width:100%;border:none;border-bottom:1px solid #ccc}
 .w3-dropdown-click,.w3-dropdown-hover{position:relative;display:inline-block;cursor:pointer}
-.w3-dropdown-hover:hover .w3-dropdown-content{display:block}
+.w3-dropdown-hover:hover > .w3-dropdown-content{display:block}
 .w3-dropdown-hover:first-child,.w3-dropdown-click:hover{background-color:#ccc;color:#000}
 .w3-dropdown-hover:hover > .w3-button:first-child,.w3-dropdown-click:hover > .w3-button:first-child{background-color:#ccc;color:#000}
 .w3-dropdown-content{cursor:auto;color:#000;background-color:#fff;display:none;position:absolute;min-width:160px;margin:0;padding:0;z-index:1}


### PR DESCRIPTION
Currently any w3-dropdown-content within a w3-dropdown-hover becomes visible on hover, making e.g. flyouts not work correctly. This tiny change makes the hover only change the immediate child w3-dropdown-content to visible, and flyouts and the like are possible.